### PR TITLE
chart: make ingress annotations configurable

### DIFF
--- a/helm/schema-server/templates/ingress.yaml
+++ b/helm/schema-server/templates/ingress.yaml
@@ -5,15 +5,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.name }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ingressClassName: nginx
   rules:
     {{- $serviceName := .Values.name -}}
-    {{- range .Values.hostnames }}
+    {{- range .Values.ingress.hostnames }}
     - host: {{ . }}
       http:
         paths:
@@ -27,7 +27,7 @@ spec:
     {{- end }}
   tls:
     - hosts:
-      {{- range .Values.hostnames }}
+      {{- range .Values.ingress.hostnames }}
       - {{ . }}
       {{- end }}
       secretName: {{ .Values.name }}

--- a/helm/schema-server/values.yaml
+++ b/helm/schema-server/values.yaml
@@ -6,9 +6,14 @@ image:
   tag: v0.0.1
   pullPolicy: IfNotPresent
 
-hostnames:
-  - schema.giantswarm.io
-  - schema.operations.awsprod.gigantic.io
+ingress:
+  hostnames:
+    - schema.giantswarm.io
+    - schema.operations.awsprod.gigantic.io
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-giantswarm
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 
 resources:
   requests:

--- a/values.schema.json
+++ b/values.schema.json
@@ -1,0 +1,1 @@
+error when reading file 'values.yaml': open values.yaml: no such file or directory


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33146

### Summary

Make the Ingress resource's annotations configurable, to allow for more flexible configuration of this app.
