### PR TITLE
Use .Chart.AppVersion for image tag templating

### DIFF
--- a/.abs/config.yaml
+++ b/.abs/config.yaml
@@ -1,0 +1,1 @@
+replace-app-version-with-git: true

--- a/.abs/config.yaml
+++ b/.abs/config.yaml
@@ -1,1 +1,0 @@
-replace-app-version-with-git: true

--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,3 +1,4 @@
+replace-app-version-with-git: true
 replace-chart-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/schema-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use .Chart.AppVersion instead of .ChartVersion in deployment template
+- Use `.Chart.AppVersion` instead of `.Chart.Version` in deployment template
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add app-build-suite config
+- Add requests and limits for ephemeral storage
 
 ## [0.3.0] - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use .Chart.AppVersion instead of .ChartVersion in deployment template
+
+### Added
+
+- Add app-build-suite config
+
 ## [0.3.0] - 2026-03-26
 
 ### Removed

--- a/helm/schema-server/templates/deployment.yaml
+++ b/helm/schema-server/templates/deployment.yaml
@@ -63,9 +63,11 @@ spec:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
               memory: {{ .Values.resources.requests.memory }}
+              ephemeral-storage: {{ .Values.resources.requests.ephemeralStorage }}
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+              ephemeral-storage: {{ .Values.resources.limits.ephemeralStorage }}
 
           livenessProbe:
             httpGet:

--- a/helm/schema-server/templates/deployment.yaml
+++ b/helm/schema-server/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
 
       containers:
         - name: {{ .Values.name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Chart.Version }}"
+          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Chart.AppVersion }}"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/helm/schema-server/values.schema.json
+++ b/helm/schema-server/values.schema.json
@@ -47,6 +47,9 @@
                         },
                         "memory": {
                             "type": "string"
+                        },
+                        "ephemeralStorage": {
+                            "type": "string"
                         }
                     }
                 },
@@ -57,6 +60,9 @@
                             "type": "string"
                         },
                         "memory": {
+                            "type": "string"
+                        },
+                        "ephemeralStorage": {
                             "type": "string"
                         }
                     }

--- a/helm/schema-server/values.yaml
+++ b/helm/schema-server/values.yaml
@@ -39,7 +39,9 @@ route:
 resources:
   requests:
     cpu: 5m
-    memory: 5M
+    memory: 5Mi
+    ephemeralStorage: 100Mi
   limits:
     cpu: 50m
-    memory: 20M
+    memory: 50Mi
+    ephemeralStorage: 500Mi


### PR DESCRIPTION
To make the chart compatible with Flux OCIRepository + HelmRelease deployment.

Also add `ephemeral-storage` request and limit to pass Kyverno policy.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
